### PR TITLE
Deprecate `reauth_token` in favor of `account`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thanks for contributing to Mono Connect Android SDK!
 
 The Mono Connect Android SDK makes it quick and easy to onboard users to Mono in your Android app. We provide a out-of-the-box way to connect your users' financial details.
 
-If you're having general trouble with Mono Connect Android SDK or your Mono integration, please reach out to us at <hi@mono.co> or come chat with us on Slack. We're proud of our level of service, and we're more than happy to help you out with your integration to Mono.
+If you're having general trouble with Mono Connect Android SDK or your Mono integration, please reach out to us at <support@mono.co> or come chat with us on Slack. We're proud of our level of service, and we're more than happy to help you out with your integration to Mono.
 
 If you've found a bug in Mono Connect Android SDK, please [let us know](https://github.com/withmono/connect-android/issues/new)! You may
 also want to check out our [issue template](https://github.com/withmono/conncet-android/tree/master/.github/ISSUE_TEMPLATE.md).

--- a/README.md
+++ b/README.md
@@ -647,7 +647,7 @@ Replace connect_public_key with your public key obtained from Mono Dashboard.
 
 
 ## Support
-If you're having general trouble with Mono Connect Android SDK or your Mono integration, please reach out to us at <hi@mono.co> or come chat with us on Slack. We're proud of our level of service, and we're more than happy to help you out with your integration to Mono.
+If you're having general trouble with Mono Connect Android SDK or your Mono integration, please reach out to us at <support@mono.co> or come chat with us on Slack. We're proud of our level of service, and we're more than happy to help you out with your integration to Mono.
 
 ## Contributing
 If you would like to contribute to the Mono Connect Android SDK, please make sure to read our [contributor guidelines](https://github.com/withmono/conect-android/tree/master/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ curl --request POST \
 ```
 
 #### Step 2: Initiate your SDK with re-authorisation config option
-With step one out of the way, pass the customer's Account ID to your config option in your installed SDK. Implementation example provided below for an Android SDK
+With step one out of the way, pass the customer's Account ID to your config option in your installed SDK. Implementation example provided below for the Android SDK
 
 ```java
 MonoConfiguration config = new MonoConfiguration.Builder(this,
@@ -354,7 +354,7 @@ timestamp: int // unix timestamp of the event as an Integer
 
 On a button click, get an auth `code` for a first time user from [Mono Connect Widget](https://docs.mono.co/docs/widgets).
 
-**Note:** Exchange tokens or a `code` must be passed to your backend for final verification with your `secretKey` for you can retrieve financial information. See [Exchange Token](https://docs.mono.co/reference/authentication-endpoint).
+**Note:** Exchange tokens or a `code` must be passed to your backend for final verification with your `secretKey` for you can retrieve financial information. See [Exchange Token](https://api.withmono.com/v2/accounts/auth).
 
 ```java
 package mono.connect.widget.sample;

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ allprojects {
 
 ```sh
 dependencies {
-  implementation 'com.github.withmono:mono-connect-android:v2.0.5'
+  implementation 'com.github.withmono:mono-connect-android:v2.1.0'
 }
 ```
 
@@ -484,7 +484,7 @@ allprojects {
 }
 
 dependencies {
-    implementation 'com.github.withmono:mono-connect-android:v2.0.5'
+    implementation 'com.github.withmono:mono-connect-android:v2.1.0'
 }
 ```
 Option 2: Add the following to your project's settings.gradle file:
@@ -499,7 +499,7 @@ dependencyResolutionManagement {
 }
 
 dependencies {
-    implementation 'com.github.withmono:mono-connect-android:v2.0.5'
+    implementation 'com.github.withmono:mono-connect-android:v2.1.0'
 }
 
 ```
@@ -592,7 +592,7 @@ dependencyResolutionManagement {
 And in the `dependencies` section of the `build.gradle` file, add the following:
 ​
 ```gradle
-implementation 'com.github.withmono:mono-connect-android:v2.0.5'
+implementation 'com.github.withmono:mono-connect-android:v2.1.0'
 ```
 ​
 ## Usage

--- a/app/src/main/java/mono/connect/widget/sample/ConnectKitExample.java
+++ b/app/src/main/java/mono/connect/widget/sample/ConnectKitExample.java
@@ -35,7 +35,7 @@ public class ConnectKitExample extends AppCompatActivity {
                 })
                 .addReference("test")
                 .addCustomer(customer)
-                .addReauthCode("code_xyz")
+//                .addAccountId("account_xyz")
                 .addOnEvent((event) -> {
                     System.out.println("Triggered: "+event.getEventName());
                     if(event.getData().has("reference")){

--- a/app/src/main/java/mono/connect/widget/sample/MainActivity.java
+++ b/app/src/main/java/mono/connect/widget/sample/MainActivity.java
@@ -34,6 +34,7 @@ public class MainActivity extends AppCompatActivity {
             })
             .addReference("f8k1jg4a82ndb")
             .addCustomer(customer)
+//            .addAccountId("account_xyz")
             .addOnEvent((event) -> {
               System.out.println("Triggered: "+event.getEventName());
               if(event.getData().has("reference")){

--- a/widget/build.gradle
+++ b/widget/build.gradle
@@ -34,7 +34,7 @@ afterEvaluate {
                 from components.release
                 groupId = 'com.github.withmono'
                 artifactId = 'connect-android'
-                version = "v2.0.5"
+                version = "v2.1.0"
                 pom {
                     description = 'The Mono Connect SDK is a quick and secure way to link bank accounts to Mono from within your Android app. Mono Connect is a drop-in framework that handles connecting a financial institution to your app.'
                 }

--- a/widget/src/main/java/mono/connect/kit/ConnectEvent.java
+++ b/widget/src/main/java/mono/connect/kit/ConnectEvent.java
@@ -5,10 +5,10 @@ import org.json.JSONObject;
 
 public class ConnectEvent {
 
-    private String eventName;
-    private JSONObject data;
+    private final String eventName;
+    private final JSONObject data;
 
-    public ConnectEvent(String eventName, JSONObject data){
+    public ConnectEvent(String eventName, JSONObject data) {
 
         this.eventName = eventName;
         this.data = data;
@@ -22,25 +22,25 @@ public class ConnectEvent {
 
         String name = "UNKNOWN";
 
-        if(type.equals("mono.connect.widget_opened")){
+        if (type.equals("mono.connect.widget_opened")) {
             name = "OPENED";
-        }else if(type.equals("mono.connect.widget.account_linked")){
+        } else if (type.equals("mono.connect.widget.account_linked")) {
             name = "SUCCESS";
-        }else if(type.equals("mono.connect.error_occured")){
+        } else if (type.equals("mono.connect.error_occured")) {
             name = "ERROR";
-        }else if(type.equals("mono.connect.institution_selected")){
+        } else if (type.equals("mono.connect.institution_selected")) {
             name = "INSTITUTION_SELECTED";
-        }else if(type.equals("mono.connect.auth_method_switched")){
+        } else if (type.equals("mono.connect.auth_method_switched")) {
             name = "AUTH_METHOD_SWITCHED";
-        }else if(type.equals("mono.connect.on_exit")){
+        } else if (type.equals("mono.connect.on_exit")) {
             name = "EXIT";
-        }else if(type.equals("mono.connect.login_attempt")){
+        } else if (type.equals("mono.connect.login_attempt")) {
             name = "SUBMIT_CREDENTIALS";
-        }else if(type.equals("mono.connect.mfa_submitted")){
+        } else if (type.equals("mono.connect.mfa_submitted")) {
             name = "SUBMIT_MFA";
-        }else if(type.equals("mono.connect.account_linked")){
+        } else if (type.equals("mono.connect.account_linked")) {
             name = "ACCOUNT_LINKED";
-        }else if(type.equals("mono.connect.account_selected")){
+        } else if (type.equals("mono.connect.account_selected")) {
             name = "ACCOUNT_SELECTED";
         }
 
@@ -51,11 +51,11 @@ public class ConnectEvent {
         return new ConnectEvent(name, body);
     }
 
-    public String getEventName(){
+    public String getEventName() {
         return this.eventName;
     }
 
-    public JSONObject getData(){
+    public JSONObject getData() {
         return this.data;
     }
 

--- a/widget/src/main/java/mono/connect/kit/ConnectKit.java
+++ b/widget/src/main/java/mono/connect/kit/ConnectKit.java
@@ -45,7 +45,9 @@ public class ConnectKit {
 
         if (config.accountId != null) {
             this.accountId = config.accountId;
-            this.params.put(Constants.KEY_SCOPE, Constants.REAUTH_SCOPE);
+            if (config.scope == null || config.scope.equals(Constants.SCOPE)) {
+                this.params.put(Constants.KEY_SCOPE, Constants.REAUTH_SCOPE);
+            }
         }
 
         if (config.onSuccess != null) {

--- a/widget/src/main/java/mono/connect/kit/ConnectKitActivity.java
+++ b/widget/src/main/java/mono/connect/kit/ConnectKitActivity.java
@@ -8,10 +8,7 @@ import android.os.Bundle;
 import android.view.View;
 import android.view.Window;
 import android.view.WindowManager;
-import android.webkit.PermissionRequest;
-import android.webkit.WebViewClient;
-import android.webkit.WebChromeClient;
-import android.webkit.WebView;
+import android.webkit.*;
 import android.widget.ProgressBar;
 import android.widget.Toast;
 
@@ -49,9 +46,9 @@ public class ConnectKitActivity extends AppCompatActivity {
     return true;
   }
 
-  private WebViewClient mWebViewClient = new WebViewClient() {
+  private final WebViewClient mWebViewClient = new WebViewClient() {
     @Override
-    public boolean shouldOverrideUrlLoading(WebView view, String url) {
+    public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
       return true;
     }
 

--- a/widget/src/main/java/mono/connect/kit/Constants.java
+++ b/widget/src/main/java/mono/connect/kit/Constants.java
@@ -4,8 +4,10 @@ public class Constants {
   public static String URL_SCHEME = "https";
   public static String CONNECT_URL = "connect.mono.co";
   public static String SCOPE = "auth";
+  public static String REAUTH_SCOPE = "reauth";
   public static String KEY_URL = "mono.connect.widget.url";
-  public static String KEY_REAUTH_TOKEN = "reauth_token";
+  public static String KEY_ACCOUNT = "account";
+  public static String KEY_SCOPE = "scope";
   public static String KEY_REFERENCE = "reference";
   public static String KEY_VERSION = "version";
   public static String VERSION = "2023-12-14";

--- a/widget/src/main/java/mono/connect/kit/Mono.java
+++ b/widget/src/main/java/mono/connect/kit/Mono.java
@@ -1,8 +1,13 @@
 package mono.connect.kit;
 
+import android.util.Log;
+
 public class Mono {
 
-    public static ConnectKit create(MonoConfiguration config){
+    public static ConnectKit create(MonoConfiguration config) {
+        if (config.accountId != null) {
+            Log.e(Constants.TAG, "You cannot pass an accountId: String to the default create function, use Mono.reauthorise() instead.");
+        }
 
         MonoWebInterface.getInstance().reset();
 
@@ -10,7 +15,10 @@ public class Mono {
 
     }
 
-    public static ConnectKit reauthorise(MonoConfiguration config){
+    public static ConnectKit reauthorise(MonoConfiguration config) {
+        if (config.accountId == null) {
+            Log.e(Constants.TAG, "Reauthorisation requires you to pass an accountId: String to the configuration object.");
+        }
 
         MonoWebInterface.getInstance().reset();
 

--- a/widget/src/main/java/mono/connect/kit/MonoConfiguration.java
+++ b/widget/src/main/java/mono/connect/kit/MonoConfiguration.java
@@ -11,7 +11,8 @@ public class MonoConfiguration {
 
     // optionals
     public String reference;
-    public String reauthCode;
+    public String scope;
+    public String accountId;
     public ConnectCloseCallback onClose;
     public ConnectEventCallback onEvent;
     public MonoInstitution selectedInstitution;
@@ -21,7 +22,8 @@ public class MonoConfiguration {
         this.context = builder.context;
         this.publicKey = builder.publicKey;
         this.reference = builder.reference;
-        this.reauthCode = builder.reauthCode;
+        this.scope = builder.scope;
+        this.accountId = builder.accountId;
         this.onSuccess = builder.onSuccess;
         this.onClose = builder.onClose;
         this.onEvent = builder.onEvent;
@@ -37,13 +39,14 @@ public class MonoConfiguration {
 
         // optionals
         private String reference = null;
-        private String reauthCode = null;
+        private String scope = Constants.SCOPE;
+        private String accountId = null;
         private ConnectCloseCallback onClose = null;
         private ConnectEventCallback onEvent = null;
         private MonoInstitution selectedInstitution = null;
         private MonoCustomer customer = null;
 
-        public Builder (Context context, String publicKey, ConnectSuccessCallback onSuccess){
+        public Builder(Context context, String publicKey, ConnectSuccessCallback onSuccess) {
             this.context = context;
             this.publicKey = publicKey;
             this.onSuccess = onSuccess;
@@ -54,27 +57,32 @@ public class MonoConfiguration {
             return this;
         }
 
-        public Builder addReauthCode(String reauthCode) {
-            this.reauthCode = reauthCode;
+        public Builder addScope(String scope) {
+            this.scope = scope;
             return this;
         }
 
-        public Builder addOnClose(ConnectCloseCallback onClose){
+        public Builder addAccountId(String accountId) {
+            this.accountId = accountId;
+            return this;
+        }
+
+        public Builder addOnClose(ConnectCloseCallback onClose) {
             this.onClose = onClose;
             return this;
         }
 
-        public Builder addOnEvent(ConnectEventCallback onEvent){
+        public Builder addOnEvent(ConnectEventCallback onEvent) {
             this.onEvent = onEvent;
             return this;
         }
 
-        public Builder addSelectedInstitution(MonoInstitution selectedInstitution){
+        public Builder addSelectedInstitution(MonoInstitution selectedInstitution) {
             this.selectedInstitution = selectedInstitution;
             return this;
         }
 
-        public Builder addCustomer(MonoCustomer customer){
+        public Builder addCustomer(MonoCustomer customer) {
             this.customer = customer;
             return this;
         }


### PR DESCRIPTION
This PR replaces `reauth_token` with `account` for account re-authorisation. The `account` field takes the Account ID of a previously linked account and passes that to the Connect Widget which then handles re-authorisation. This eliminates the need for partners to make an extra call to the [reauthorise endpoint](https://docs.mono.co/api/bank-data/reauth) for a `reauth_token`.

[Demo Video.webm](https://github.com/user-attachments/assets/22660bbf-f926-472b-a32e-4e1a14a00d21)
