### PR TITLE
Mono fx support Android 6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ allprojects {
 
 ```sh
 dependencies {
-  implementation 'com.github.withmono:mono-connect-android:v2.1.0'
+  implementation 'com.github.withmono:mono-connect-android:v2.2.0'
 }
 ```
 
@@ -484,7 +484,7 @@ allprojects {
 }
 
 dependencies {
-    implementation 'com.github.withmono:mono-connect-android:v2.1.0'
+    implementation 'com.github.withmono:mono-connect-android:v2.2.0'
 }
 ```
 Option 2: Add the following to your project's settings.gradle file:
@@ -499,7 +499,7 @@ dependencyResolutionManagement {
 }
 
 dependencies {
-    implementation 'com.github.withmono:mono-connect-android:v2.1.0'
+    implementation 'com.github.withmono:mono-connect-android:v2.2.0'
 }
 
 ```
@@ -592,7 +592,7 @@ dependencyResolutionManagement {
 And in the `dependencies` section of the `build.gradle` file, add the following:
 ​
 ```gradle
-implementation 'com.github.withmono:mono-connect-android:v2.1.0'
+implementation 'com.github.withmono:mono-connect-android:v2.2.0'
 ```
 ​
 ## Usage

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "mono.connect.widget.sample"
-        minSdk 24
+        minSdk 23
         targetSdk 33
         versionCode 1
         versionName "1.0"

--- a/widget/build.gradle
+++ b/widget/build.gradle
@@ -34,7 +34,7 @@ afterEvaluate {
                 from components.release
                 groupId = 'com.github.withmono'
                 artifactId = 'connect-android'
-                version = "v2.1.0"
+                version = "v2.2.0"
                 pom {
                     description = 'The Mono Connect SDK is a quick and secure way to link bank accounts to Mono from within your Android app. Mono Connect is a drop-in framework that handles connecting a financial institution to your app.'
                 }

--- a/widget/build.gradle
+++ b/widget/build.gradle
@@ -8,7 +8,7 @@ android {
 
     defaultConfig {
         targetSdk 33
-        minSdk 24
+        minSdk 23
         versionCode 1
         versionName "1.0"
 

--- a/widget/src/main/java/mono/connect/kit/ConnectKitActivity.java
+++ b/widget/src/main/java/mono/connect/kit/ConnectKitActivity.java
@@ -78,9 +78,6 @@ public class ConnectKitActivity extends AppCompatActivity {
     supportRequestWindowFeature(Window.FEATURE_NO_TITLE);
     enableEdgeToEdge();
 
-    getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,
-            WindowManager.LayoutParams.FLAG_FULLSCREEN);
-
     super.onCreate(bundle);
     setContentView(R.layout.main);
 

--- a/widget/src/main/java/mono/connect/kit/ConnectKitActivity.java
+++ b/widget/src/main/java/mono/connect/kit/ConnectKitActivity.java
@@ -164,6 +164,7 @@ public class ConnectKitActivity extends AppCompatActivity {
       }
     }
   }
+
   private void enableEdgeToEdge() {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return;
 

--- a/widget/src/main/java/mono/connect/kit/ConnectKitActivity.java
+++ b/widget/src/main/java/mono/connect/kit/ConnectKitActivity.java
@@ -3,6 +3,7 @@ package mono.connect.kit;
 import android.Manifest;
 import android.annotation.SuppressLint;
 import android.content.pm.PackageManager;
+import android.graphics.Color;
 import android.os.Build;
 import android.os.Bundle;
 import android.view.View;
@@ -16,6 +17,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.app.ActivityCompat;
+import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsControllerCompat;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -73,6 +76,8 @@ public class ConnectKitActivity extends AppCompatActivity {
   @Override
   protected void onCreate(@Nullable Bundle bundle) {
     supportRequestWindowFeature(Window.FEATURE_NO_TITLE);
+    enableEdgeToEdge();
+
     getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,
             WindowManager.LayoutParams.FLAG_FULLSCREEN);
 
@@ -99,8 +104,8 @@ public class ConnectKitActivity extends AppCompatActivity {
     mWebView.getSettings().setAllowUniversalAccessFromFileURLs(true);
     mWebView.getSettings().setJavaScriptCanOpenWindowsAutomatically(true);
     mWebView.getSettings().setBuiltInZoomControls(true);
-    mWebView.getSettings().setMediaPlaybackRequiresUserGesture(true);
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+    mWebView.getSettings().setMediaPlaybackRequiresUserGesture(false);
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
       mWebView.getSettings().setSafeBrowsingEnabled(true);
     }
     mWebView.getSettings().setSupportZoom(true);
@@ -158,5 +163,21 @@ public class ConnectKitActivity extends AppCompatActivity {
         finish();
       }
     }
+  }
+  private void enableEdgeToEdge() {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return;
+
+    Window window = getWindow();
+
+    WindowCompat.setDecorFitsSystemWindows(window, false);
+
+    window.setStatusBarColor(Color.TRANSPARENT);
+    window.setNavigationBarColor(Color.TRANSPARENT);
+
+    WindowInsetsControllerCompat controller =
+            new WindowInsetsControllerCompat(window, window.getDecorView());
+
+    controller.setAppearanceLightStatusBars(true);
+    controller.setAppearanceLightNavigationBars(true);
   }
 }


### PR DESCRIPTION
# Mono fx support Android 6.0

## Summary
1. Lowers `minSdk` version to 23(Android 6.0).